### PR TITLE
Adding options for HTTP-API to be able to debug and review Eufy-P2P-Streams running through RSTP-server

### DIFF
--- a/config.json
+++ b/config.json
@@ -13,7 +13,8 @@
   "legacy": true,
   "ports": {
     "8554/tcp": 8554,
-    "1935/tcp": 1935
+    "1935/tcp": 1935,
+	"9997/tcp": 9997
   },
   "startup": "application",
   "options": {

--- a/config.json
+++ b/config.json
@@ -34,6 +34,7 @@
 	  "RTSP_PATHS_ALL_RUNONDEMANDRESTART": "yes"
   },
   "schema": {
+	  "HTTP-api": "list(yes)",
 	  "RTSP_PROTOCOLS": "list(tcp)",
 	  "RTSP_PATHS_ALL_RUNONDEMAND": "list(echo 'incoming')",
 	  "RTSP_PATHS_ALL_RUNONDEMANDRESTART": "list(yes)"

--- a/config.json
+++ b/config.json
@@ -28,13 +28,13 @@
   ,
   "startup": "application",
   "options": {
-	  "RSTP_API": "yes",
+	  "RTSP_API": "yes",
 	  "RTSP_PROTOCOLS": "tcp",
 	  "RTSP_PATHS_ALL_RUNONDEMAND": "echo 'incoming'",
 	  "RTSP_PATHS_ALL_RUNONDEMANDRESTART": "yes"
   },
   "schema": {
-	  "RSTP_API": "list(yes)",
+	  "RTSP_API": "list(yes)",
 	  "RTSP_PROTOCOLS": "list(tcp)",
 	  "RTSP_PATHS_ALL_RUNONDEMAND": "list(echo 'incoming')",
 	  "RTSP_PATHS_ALL_RUNONDEMANDRESTART": "list(yes)"

--- a/config.json
+++ b/config.json
@@ -16,9 +16,9 @@
     "config:rw"
   ],
   "ports": {
-    "8554/tcp": 8554,
     "1935/tcp": 1935,
-	"9997/tcp": 9997
+	"8554/tcp": 8554,
+    "9997/tcp": 9997
   },
   "ports_description": {
     "8554/tcp": "RTSP protocol supports the TCP transport protocol",
@@ -28,13 +28,13 @@
   ,
   "startup": "application",
   "options": {
-	  "api": "yes",
+	  "RSTP_API": "yes",
 	  "RTSP_PROTOCOLS": "tcp",
 	  "RTSP_PATHS_ALL_RUNONDEMAND": "echo 'incoming'",
 	  "RTSP_PATHS_ALL_RUNONDEMANDRESTART": "yes"
   },
   "schema": {
-	  "HTTP-api": "list(yes)",
+	  "RSTP_API": "list(yes)",
 	  "RTSP_PROTOCOLS": "list(tcp)",
 	  "RTSP_PATHS_ALL_RUNONDEMAND": "list(echo 'incoming')",
 	  "RTSP_PATHS_ALL_RUNONDEMANDRESTART": "list(yes)"

--- a/config.json
+++ b/config.json
@@ -36,7 +36,7 @@
   },
   "schema": {
 	  "RTSP_API": "list(yes)",
-	  "RTSP_APIADDRESS": "string(:9997)",
+	  "RTSP_APIADDRESS": "list(:9997)",
 	  "RTSP_PROTOCOLS": "list(tcp)",
 	  "RTSP_PATHS_ALL_RUNONDEMAND": "list(echo 'incoming')",
 	  "RTSP_PATHS_ALL_RUNONDEMANDRESTART": "list(yes)"

--- a/config.json
+++ b/config.json
@@ -36,7 +36,7 @@
   },
   "schema": {
 	  "RTSP_API": "list(yes)",
-	  "RTSP_APIADDRESS": "list(9997)",
+	  "RTSP_APIADDRESS": "string(:9997)",
 	  "RTSP_PROTOCOLS": "list(tcp)",
 	  "RTSP_PATHS_ALL_RUNONDEMAND": "list(echo 'incoming')",
 	  "RTSP_PATHS_ALL_RUNONDEMANDRESTART": "list(yes)"

--- a/config.json
+++ b/config.json
@@ -22,8 +22,8 @@
   },
   "ports_description": {
     "8554/tcp": "RTSP protocol supports the TCP transport protocol",
-	"1935/tcp": "No idea what this is for.",
-	"9997/tcp": "HTTP api through http://127.0.0.1:9997/v1/paths/list."
+    "1935/tcp": "No idea what this is for.",
+    "9997/tcp": "HTTP api through http://127.0.0.1:9997/v1/paths/list."
   }
   ,
   "startup": "application",
@@ -36,7 +36,7 @@
   },
   "schema": {
 	  "RTSP_API": "list(yes)",
-	  "RTSP_APIADDRESS": "string(9997)",
+	  "RTSP_APIADDRESS": "list(9997)",
 	  "RTSP_PROTOCOLS": "list(tcp)",
 	  "RTSP_PATHS_ALL_RUNONDEMAND": "list(echo 'incoming')",
 	  "RTSP_PATHS_ALL_RUNONDEMANDRESTART": "list(yes)"

--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
   "name": "RTSP Simple Server Add-on",
-  "version": "v0.17.6",
+  "version": "v0.17.7",
   "slug": "rtsp_simple_server",
   "description": "Create RTSP server to broadcast streams, thanks to @aler9 - https://github.com/aler9/rtsp-simple-server",
   "arch": [
@@ -9,15 +9,26 @@
     "armhf",
     "armv7"
   ],
-"boot": "auto",
+  "boot": "auto",
   "legacy": true,
+  "map": [
+    "share:rw",
+    "config:rw"
+  ],
   "ports": {
     "8554/tcp": 8554,
     "1935/tcp": 1935,
 	"9997/tcp": 9997
   },
+  "ports_description": {
+    "8554/tcp": "RTSP protocol supports the TCP transport protocol",
+	"1935/tcp": "No idea what this is for.",
+	"9997/tcp": "HTTP api through http://127.0.0.1:9997/v1/paths/list."
+  }
+  ,
   "startup": "application",
   "options": {
+	  "api": "yes",
 	  "RTSP_PROTOCOLS": "tcp",
 	  "RTSP_PATHS_ALL_RUNONDEMAND": "echo 'incoming'",
 	  "RTSP_PATHS_ALL_RUNONDEMANDRESTART": "yes"

--- a/config.json
+++ b/config.json
@@ -17,7 +17,7 @@
   ],
   "ports": {
     "1935/tcp": 1935,
-	"8554/tcp": 8554,
+    "8554/tcp": 8554,
     "9997/tcp": 9997
   },
   "ports_description": {
@@ -29,12 +29,14 @@
   "startup": "application",
   "options": {
 	  "RTSP_API": "yes",
+	  "RTSP_APIADDRESS": ":9997",
 	  "RTSP_PROTOCOLS": "tcp",
 	  "RTSP_PATHS_ALL_RUNONDEMAND": "echo 'incoming'",
 	  "RTSP_PATHS_ALL_RUNONDEMANDRESTART": "yes"
   },
   "schema": {
 	  "RTSP_API": "list(yes)",
+	  "RTSP_APIADDRESS": "string(9997)",
 	  "RTSP_PROTOCOLS": "list(tcp)",
 	  "RTSP_PATHS_ALL_RUNONDEMAND": "list(echo 'incoming')",
 	  "RTSP_PATHS_ALL_RUNONDEMANDRESTART": "list(yes)"

--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
   "name": "RTSP Simple Server Add-on",
-  "version": "v0.17.7",
+  "version": "v0.17.11",
   "slug": "rtsp_simple_server",
   "description": "Create RTSP server to broadcast streams, thanks to @aler9 - https://github.com/aler9/rtsp-simple-server",
   "arch": [

--- a/repository.json
+++ b/repository.json
@@ -1,5 +1,5 @@
 {
     "name": "RTSP Simple Server Addon",
-    "url": "https://github.com/fuatakgun/rtsp_simple_server_addon",
-    "maintainer": "Fuat Akgun <fuatakgun@gmail.com>"
+    "url": "https://github.com/rwunsch/rtsp_simple_server",
+    "maintainer": "Robert Wunsch <wunsch@gmx.de>"
 }


### PR DESCRIPTION
Hi @fuatakgun ,

I had the issue that I wanted to push my Eufy-P2P stream into Frigate (NVR).
But I did not know the input-stream-ID defined by the eufy_security-add-on.

I think exposing the HTTP-API port 9997 might make sense - which can then be queried  through the browser:
* eg http://<HA-URL_OR-IP>:9997/v1/paths/list
* Documentation: https://aler9.github.io/rtsp-simple-server/

I also bumped the version of the RTSP-add-on to v.0.17.11 .

Hope you agree and accept the pull-request.

Thanks and cheers - Robert